### PR TITLE
Change title from this.js to Hamsters.js

### DIFF
--- a/src/hamsters.js
+++ b/src/hamsters.js
@@ -1,5 +1,5 @@
   /*
-  * Title: this.js
+  * Title: Hamsters.js
   * Description: Javascript library to add multi-threading support to javascript by exploiting concurrent web workers
   * Author: Austin K. Smith
   * Contact: austin@asmithdev.com


### PR DESCRIPTION
Was looking at the source code for your awesome library and noticed that the title was wrong. Thought I'd save you the trouble.